### PR TITLE
[GH-6] Scope the deleteshape keybinding to avoid overlap with delete key

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 			{
 				"command": "brijeshb42-excalidraw.deleteshape",
 				"key": "Delete",
-				"when": "editorIsOpen"
+				"when": "editorIsOpen && !editorReadonly && resourceExtname == .excalidraw"
 			}
 		]
 	},


### PR DESCRIPTION
Since the extension already has a `"filenamePattern": "*.excalidraw"` selector, there's no need to override keybindings outside these files

Based on the docs: https://code.visualstudio.com/api/references/when-clause-contexts

fixes #6 